### PR TITLE
(initial_commit) monitor_pv: Introduces a textfile collector based pv stats monitor for OpenEBS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+dist: xenial
+
+language: minimal
+
+services:
+  - docker
+
+jobs:
+  include:
+    - os: linux
+      arch: amd64
+      env:
+        - DIMAGE="openebs/monitor-pv"
+        - TRIVYARCH="64bit"
+    - os: linux
+      arch: arm64
+      env:
+        - DIMAGE="openebs/monitor-pv-arm64"
+        - TRIVYARCH="ARM64"
+
+before_install:
+  - export VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+  - echo ${VERSION} 
+  - wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-${TRIVYARCH}.tar.gz
+  - tar zxvf trivy_${VERSION}_Linux-${TRIVYARCH}.tar.gz
+
+script:
+  - make image
+  - make test
+  - ./trivy --exit-code 0 --severity HIGH --no-progress ${DIMAGE}:ci
+  - ./trivy --exit-code 1 --severity CRITICAL --no-progress ${DIMAGE}:ci
+
+after_success:
+  - make push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+LABEL maintainer="OpenEBS"
+RUN apt-get update || true \
+    && apt-get install -y curl
+ENV KUBE_LATEST_VERSION="v1.15.3"
+RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+ && chmod +x /usr/local/bin/kubectl
+COPY textfile_collector.sh /

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+# Copyright 2018-2019 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ==============================================================================
+# Build Options
+
+# Determine the DIMAGE associated with given arch/os
+ifeq (${DIMAGE}, )
+  #Default image name
+  DIMAGE:=openebs/monitor-pv
+  XC_ARCH:=$(shell uname -m)
+  ifeq (${XC_ARCH},aarch64)
+    DIMAGE="openebs/monitor-pv-arm64"
+  endif
+  export DIMAGE
+endif
+
+# Compile binaries and build docker images
+.PHONY: build
+build: image push
+
+.PHONY: header
+header:
+	@echo "------------------------------------"
+	@echo "--> Building monitor pv image      "
+	@echo "------------------------------------"
+	@echo
+
+.PHONY: image
+image: header
+	@sudo docker build -t "${DIMAGE}:ci" -f Dockerfile .
+	@echo
+
+.PHONY: test
+test:
+	@echo "---------------------------------------"
+	@echo "--> Test required tools are available  "
+	@echo "---------------------------------------"
+	@sudo docker run "${DIMAGE}:ci" bash --version
+	@sudo docker run "${DIMAGE}:ci" which df
+	@sudo docker run "${DIMAGE}:ci" which du
+	@sudo docker run "${DIMAGE}:ci" which kubectl
+
+.PHONY: push
+push:
+	./buildscripts/push;

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # monitor-pv
-custom stats collector for OpenEBS persistent volumes
+custom stats collector for OpenEBS persistent volumes (jiva, localpv)

--- a/buildscripts/push
+++ b/buildscripts/push
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -e
+
+if [ -z ${DIMAGE} ];
+then
+  echo "Error: DIMAGE is not specified";
+  exit 1
+fi
+
+IMAGEID=$( sudo docker images -q ${DIMAGE}:ci )
+echo "${DIMAGE}:ci -> $IMAGEID"
+if [ -z ${IMAGEID} ];
+then
+  echo "Error: unable to get IMAGEID for ${DIMAGE}:ci";
+  exit 1
+fi
+
+# Generate a unique tag based on the commit and tag
+BUILD_ID=$(git describe --tags --always)
+
+# Determine the current branch
+CURRENT_BRANCH=""
+if [ -z ${TRAVIS_BRANCH} ];
+then
+  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+else
+  CURRENT_BRANCH=${TRAVIS_BRANCH}
+fi
+
+#Depending on the branch where builds are generated,
+# set the tag CI (fixed) and build tags.
+BUILD_TAG="${CURRENT_BRANCH}-${BUILD_ID}"
+CI_TAG="${CURRENT_BRANCH}-ci"
+if [ ${CURRENT_BRANCH} = "master" ]; then
+  CI_TAG="ci"
+fi
+
+echo "Set the fixed ci image tag as: ${CI_TAG}"
+echo "Set the build/unique image tag as: ${BUILD_TAG}"
+
+function TagAndPushImage() {
+  REPO="$1"
+  TAG="$2"
+
+  IMAGE_URI="${REPO}:${TAG}";
+  sudo docker tag ${IMAGEID} ${IMAGE_URI};
+  echo " push ${IMAGE_URI}";
+  sudo docker push ${IMAGE_URI};
+}
+
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ];
+then
+  sudo docker login -u "${DNAME}" -p "${DPASS}";
+
+  # Push CI tagged image - :ci or :branch-ci
+  TagAndPushImage "${DIMAGE}" "${CI_TAG}"
+
+  # Push unique tagged image - :master-<uuid> or :branch-<uuid>
+  # This unique/build image will be pushed to corresponding ci repo.
+  TagAndPushImage "${DIMAGE}-ci" "${BUILD_TAG}"
+
+  if [ ! -z "${TRAVIS_TAG}" ] ;
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env TRAVIS_TAG
+    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG}"
+    TagAndPushImage "${DIMAGE}" "latest"
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading ${DIMAGE} to docker hub";
+fi;
+
+# Push ci image to quay.io for security scanning
+if [ ! -z "${QNAME}" ] && [ ! -z "${QPASS}" ];
+then
+  sudo docker login -u "${QNAME}" -p "${QPASS}" quay.io;
+
+  # Push CI tagged image - :ci or :branch-ci
+  TagAndPushImage "quay.io/${DIMAGE}" "${CI_TAG}"
+
+  if [ ! -z "${TRAVIS_TAG}" ] ;
+  then
+    # Push with different tags if tagged as a release
+    # When github is tagged with a release, then Travis will
+    # set the release tag in env TRAVIS_TAG
+    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
+    TagAndPushImage "quay.io/${DIMAGE}" "latest"
+  fi;
+else
+  echo "No docker credentials provided. Skip uploading ${DIMAGE} to quay";
+fi;
+
+#Push image to run openebs-e2e based on git commit
+if [ ! -z "${COMMIT}" ];
+then
+  sudo docker login -u "${GITLAB_DNAME}" -p "${GITLAB_DPASS}";
+
+  # Push COMMIT tagged image - :COMMIT
+  TagAndPushImage "${DIMAGE}" "${COMMIT}"
+fi;

--- a/textfile_collector.sh
+++ b/textfile_collector.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+FILEPATH=${TEXTFILE_PATH:=/shared_vol}
+INTERVAL=${COLLECT_INTERVAL:=10}
+
+## calculate_pv_capacity obtains the size of a PV in bytes
+function calculate_pv_capacity(){
+
+  unit=$(echo "${size_in_spec: -1}")
+
+  case "${unit}" in 
+  
+  g|gi) echo $((1024*1024*1024*$(echo $1 | cut -d "${unit}" -f 1)))
+     ;;
+  m|mi) echo $((1024*1024*$(echo $1 | cut -d "${unit}" -f 1)))
+     ;;
+  k|ki) echo $((1024*$(echo $1 | cut -d "${unit}" -f 1)))
+     ;;
+  b|bi) echo $1 | cut -d "${unit}" -f 1
+     ;;
+  *) echo 0
+     ;;
+  esac
+}
+
+## collect_pv_capacity_metrics collects the PV capacity metrics
+function collect_pv_capacity_metrics(){
+ 
+  ##TODO: We clear the file and then proceed to derive the metrics in the for loop below.
+  ## If, the block below takes time, it may cause a few seconds of "no-metrics". 
+  ## This needs to be optimized. Preferable approach is to replace values v/s recreating the file.  
+  > ${FILEPATH}/pv_size.prom
+
+  for i in ${pv_list[@]}
+  do
+    size_in_spec=$(kubectl get pv ${i} -o custom-columns=:spec.capacity.storage --no-headers | tr '[:upper:]' '[:lower:]')
+    size_in_bytes=$(calculate_pv_capacity ${size_in_spec};)
+    echo "pv_capacity_bytes{persistentvolume=\"${i}\"} ${size_in_bytes}" >> ${FILEPATH}/pv_size.prom
+  done
+}
+
+## collect_pv_utilization_metrics collects the PV utilization metrics
+function collect_pv_utilization_metrics(){
+
+  ##TODO: We clear the file and then proceed to derive the metrics in the for loop below.
+  ## If, the block below takes time, it may cause a few seconds of "no-metrics". 
+  ## This needs to be optimized. Preferable approach is to replace values v/s recreating the file.  
+  > ${FILEPATH}/pv_used.prom
+
+  declare -a pv_mount_list=()
+
+  for i in ${pv_list[@]}
+  do
+    pv_mount_list+=($(df -h | grep ${i} | awk '{print $NF}'))
+  done
+
+  echo "mount list: ${pv_mount_list[@]}"
+  for i in ${pv_mount_list[@]}
+  do
+    ## Get mount point utilization in bytes
+    mount_data=$(du -sb ${i})
+    utilization=$(echo ${mount_data}| cut -d " " -f 1)
+    pv_name=$(basename $(echo ${mount_data} | cut -d " " -f 2))
+    echo "pv_utilization_bytes{persistentvolume=\"${pv_name}\"} ${utilization}" >> ${FILEPATH}/pv_used.prom
+  done
+}
+
+while true
+do
+  declare -a pv_list=()
+
+  ## Select only those PVs that are bound. Several stale PVs can exist.
+  for i in $(kubectl get pv -o jsonpath='{.items[?(@.status.phase=="Bound")].metadata.name}')
+  do
+    pv_list+=(${i})
+  done
+
+  echo "pv_list: ${pv_list[@]}"
+  collect_pv_capacity_metrics;
+  collect_pv_utilization_metrics;
+  sleep ${INTERVAL}
+done


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

 This PR introduces the alpha version of a persistent volume capacity monitor container for Kubernetes. It is typically expected to be deployed as a sidecar to the node-exporter on the cluster. The container uses the textfile collector approach to gather the PV metrics, while allowing node-exporter to expose them. The flow/working & usage  details of the collector is provided below:  

- The pod running this container is expected to use a service account with cluster-level scope. (In case of the openebs node-exporter: openebs-maya-operator)

- The pv-monitor sidecar is expected to have similar volume mounts as the node-exporter, including the host root fs configured with a HostToContainer propagation to detect new PV mounts on the host.

- A list of active/Bound PVs is obtained, which capacity/size & current utilization are gathered. The utilization is obtained via the `du` command on the PVs mounted at the `/var/lib/kubelet/pods/<>` paths

- A set of of textfiles are updated into a specified shared path (achieved by a shared temp volume such as emptyDir{}), via a polling mechanism, with configurable intervals in a format desired by the node-exporter:

```
pv_capacity_bytes{persistentvolume="pvc-8b6eb31b-cecd-11e9-b8b2-42010a800039"} 5368709120
pv_capacity_bytes{persistentvolume="pvc-577bc663-cf18-11e9-b8b2-42010a800039"} 5368709120
```
```
pv_utilization_bytes{persistentvolume="pvc-8b6eb31b-cecd-11e9-b8b2-42010a800039"} 218944
pv_utilization_bytes{persistentvolume="pvc-577bc663-cf18-11e9-b8b2-42010a800039"} 218824
```
- The node-exporter is configured to monitor the textfile collector directories. 

```
--collector.textfile.directory=/shared_vol
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- Subsequent improvements can include ability to replace values on the textfiles instead of recreate, using a lighter base image & making the scripts more robust for failure conditions (change to python/go). Other approaches to expose the kubelet_volume_stats metrics on the individual nodes (instead of du/df operations) will also be considered. 

- Sample dashboard showing utilization percentages with the prom query: `((pv_utilization_bytes) *100 / pv_capacity_bytes)` 

![image](https://user-images.githubusercontent.com/21166217/64344996-25de7900-d00d-11e9-898b-f76119ad9986.png)
