### PR TITLE
(fix): add support for OpenEBS local PVs 

### DIFF
--- a/node-exporter.yaml
+++ b/node-exporter.yaml
@@ -1,11 +1,14 @@
 # monitor-pv will be launch as daemonset.
 # choose appropriate namespace and serviceaccount. defaults to ns: openebs, sa: openebs-maya-operator
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: monitor-pv
   namespace: openebs
 spec:
+  selector:
+    matchLabels:
+      app: monitor-pv
   template:
     metadata:
       labels:

--- a/node-exporter.yaml
+++ b/node-exporter.yaml
@@ -1,0 +1,122 @@
+# node-exporter will be launch as daemonset.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: openebs
+spec:
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+      name: node-exporter
+    spec:
+      serviceAccount: openebs-maya-operator
+      containers:
+      #- image: prom/node-exporter:v0.18.1
+      - image: quay.io/prometheus/node-exporter:v0.18.1 
+        args:
+          - --path.procfs=/host/proc
+          - --path.sysfs=/host/sys
+          - --path.rootfs=/host/root
+          - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib|run|boot|home/kubernetes/.+)($|/)
+          - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+          - --collector.textfile.directory=/shared_vol
+        name: node-exporter
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: scrape
+        resources:
+            requests:
+              # A memory request of 250M means it will try to ensure minimum
+              # 250MB RAM .
+              memory: "128M"
+              # A cpu request of 128m means it will try to ensure minimum
+              # .125 CPU; where 1 CPU means :
+              # 1 *Hyperthread* on a bare-metal Intel processor with Hyperthreading
+              cpu: "128m"
+            limits:
+              memory: "700M"
+              cpu: "500m"
+        volumeMounts:
+        # All the application data stored in data-disk
+        - name: proc
+          mountPath: /host/proc
+          readOnly: false
+        # Root disk is where OS(Node) is installed
+        - name: sys
+          mountPath: /host/sys
+          readOnly: false
+        - name: root
+          mountPath: /host/root
+          mountPropagation: HostToContainer
+          readOnly: true
+        - name: tmpvol
+          mountPath: /shared_vol
+      - name: pv-monitor
+        image: ksatchit/monitor-pv:ci
+        imagePullPolicy: Always
+        env:
+          - name: TEXTFILE_PATH
+            value: /shared_vol
+          - name: COLLECT_INTERVAL 
+            value: "10"
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - ./textfile_collector.sh
+        volumeMounts:
+        - mountPath: /host/proc
+          name: proc
+        - mountPath: /host/sys
+          name: sys
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+        - mountPath: /shared_vol
+          name: tmpvol 
+      # The Kubernetes scheduler’s default behavior works well for most cases
+      # -- for example, it ensures that pods are only placed on nodes that have 
+      # sufficient free resources, it ties to spread pods from the same set 
+      # (ReplicaSet, StatefulSet, etc.) across nodes, it tries to balance out 
+      # the resource utilization of nodes, etc.
+      #
+      # But sometimes you want to control how your pods are scheduled. For example,
+      # perhaps you want to ensure that certain pods only schedule on nodes with 
+      # specialized hardware, or you want to co-locate services that communicate 
+      # frequently, or you want to dedicate a set of nodes to a particular set of 
+      # users. Ultimately, you know much more about how your applications should be
+      # scheduled and deployed than Kubernetes ever will.
+      #
+      # “taints and tolerations,” allows you to mark (“taint”) a node so that no 
+      # pods can schedule onto it unless a pod explicitly “tolerates” the taint.
+      # toleration  is particularly useful for situations where most pods in 
+      # the cluster should avoid scheduling onto the node. In our case we want
+      # node-exporter to run on master node also i.e, we want to collect metrics 
+      # from master node. That's why tolerations added.
+      # if removed master's node metrics can't be scrapped by prometheus.
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+        # A hostPath volume mounts a file or directory from the host node’s 
+        # filesystem.For example, some uses for a hostPath are:
+        # running a container that needs access to Docker internals; use a hostPath 
+        # of /var/lib/docker
+        # running cAdvisor in a container; use a hostPath of /dev/cgroups
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: root
+          hostPath:
+            path: /
+        - name: tmpvol
+          emptyDir: {}
+      hostNetwork: true
+      hostPID: true

--- a/node-exporter.yaml
+++ b/node-exporter.yaml
@@ -1,19 +1,19 @@
-# node-exporter will be launch as daemonset.
+# monitor-pv will be launch as daemonset.
+# choose appropriate namespace and serviceaccount. defaults to ns: openebs, sa: openebs-maya-operator
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: node-exporter
+  name: monitor-pv
   namespace: openebs
 spec:
   template:
     metadata:
       labels:
-        app: node-exporter
-      name: node-exporter
+        app: monitor-pv
+      name: monitor-pv
     spec:
       serviceAccount: openebs-maya-operator
       containers:
-      #- image: prom/node-exporter:v0.18.1
       - image: quay.io/prometheus/node-exporter:v0.18.1 
         args:
           - --path.procfs=/host/proc
@@ -54,8 +54,8 @@ spec:
           readOnly: true
         - name: tmpvol
           mountPath: /shared_vol
-      - name: pv-monitor
-        image: ksatchit/monitor-pv:ci
+      - name: monitor-pv
+        image: openebs/monitor-pv:ci
         imagePullPolicy: Always
         env:
           - name: TEXTFILE_PATH
@@ -78,35 +78,10 @@ spec:
           readOnly: true
         - mountPath: /shared_vol
           name: tmpvol 
-      # The Kubernetes scheduler’s default behavior works well for most cases
-      # -- for example, it ensures that pods are only placed on nodes that have 
-      # sufficient free resources, it ties to spread pods from the same set 
-      # (ReplicaSet, StatefulSet, etc.) across nodes, it tries to balance out 
-      # the resource utilization of nodes, etc.
-      #
-      # But sometimes you want to control how your pods are scheduled. For example,
-      # perhaps you want to ensure that certain pods only schedule on nodes with 
-      # specialized hardware, or you want to co-locate services that communicate 
-      # frequently, or you want to dedicate a set of nodes to a particular set of 
-      # users. Ultimately, you know much more about how your applications should be
-      # scheduled and deployed than Kubernetes ever will.
-      #
-      # “taints and tolerations,” allows you to mark (“taint”) a node so that no 
-      # pods can schedule onto it unless a pod explicitly “tolerates” the taint.
-      # toleration  is particularly useful for situations where most pods in 
-      # the cluster should avoid scheduling onto the node. In our case we want
-      # node-exporter to run on master node also i.e, we want to collect metrics 
-      # from master node. That's why tolerations added.
-      # if removed master's node metrics can't be scrapped by prometheus.
       tolerations:
       - effect: NoSchedule
         operator: Exists
       volumes:
-        # A hostPath volume mounts a file or directory from the host node’s 
-        # filesystem.For example, some uses for a hostPath are:
-        # running a container that needs access to Docker internals; use a hostPath 
-        # of /var/lib/docker
-        # running cAdvisor in a container; use a hostPath of /dev/cgroups
         - name: proc
           hostPath:
             path: /proc


### PR DESCRIPTION
### Changes

This PR consists of some small improvements to the existing monitor-pv bash script. 

- Uses `findmnt --df` as a way to determine PV mount points over using `df`. The local PV mounts do not show up in case of the latter. Findmnt has a broader reach, i.e., looks for filesystems in `/etc/mtab`, `/etc/fstab` & `/proc/self/mountinfo` by default. the `--df` flag (outputs in similar format as df) has been used to enable simpler command output parse. 

- The mount points for a given PV are filtered to the one in this path `var/lib/kubelet/pods` as this is the constant in a list of several mounts (including those depending on PV type and Cluster type. For example, `/var/lib/kubelet/plugins/`, `/home/kubernetes/containerized_mounter/`) 

- Fixes the command to obtain volume capacity in bytes 
  - Determines whether the unit of PV contains "i" 
  - `cut` doesn't accept multi-character delimiter, so `tr` is used instead

- Adds a sample deployment spec that uses openebs namespace and serviceaccount. 

Signed-off-by: ksatchit <karthik.s@mayadata.io>