### PR TITLE
Updated kubectl & cleaned up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM ubuntu:16.04
-LABEL maintainer="OpenEBS"
-RUN apt-get update || true \
-    && apt-get install -y curl
-ENV KUBE_LATEST_VERSION="v1.15.3"
-RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
- && chmod +x /usr/local/bin/kubectl
+FROM ubuntu:22.04 AS build
+RUN apt-get update \
+    && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG KUBE_LATEST_VERSION="v1.25.2"
+RUN cd /root \
+    && curl -LO https://dl.k8s.io/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl \
+    && curl -LO https://dl.k8s.io/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl.sha256 \
+    && echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check \
+    && chmod -v +x kubectl
+
+FROM ubuntu:22.04 AS final
+
+COPY --from=build /root/kubectl /usr/local/bin/kubectl
 COPY textfile_collector.sh /
+
+ENTRYPOINT ["/textfile_collector.sh"]
+LABEL maintainer="OpenEBS"


### PR DESCRIPTION
- Updated to Ubuntu 22.04
- Fixed so `curl` and APT cache isn't shipped with the repo
- Updated Kubectl to `v1.25.2`
